### PR TITLE
Footer position styling fix

### DIFF
--- a/scripts/run_be.ps1
+++ b/scripts/run_be.ps1
@@ -1,0 +1,2 @@
+cd backend/cgi-bin
+$env:FLASK_APP="api.py" flask run --reload

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,7 +32,7 @@ export const App = () => {
 
     return (
         <Router>
-            <div className="mx-auto w-[95%] lg:w-[75%]">
+            <div className="mx-auto w-[95%] lg:w-[75%] grid min-h-screen grid-rows-[auto,1fr,auto]">
                 <AuthProvider>
 
                     <Header />

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -6,7 +6,7 @@ export const Footer = (): React.JSX.Element => {
 
     return (
 
-        <div className="bg-c-green text-white p-2 font-roboto m-auto text-center md:text-start">
+        <div className="bg-c-green text-white p-2 font-roboto text-center md:text-start">
             <div className="flex flex-wrap p-6">
                 <div className="w-full lg:w-1/4 px-4 flex justify-center md:block">
                     <img src={require("@images/churchlogo-footer.png")} alt="St. George Logo Header" className="h-auto object-contain w-[120px] md:w-[160px]"></img>

--- a/src/screens/Calendar/Calendar.tsx
+++ b/src/screens/Calendar/Calendar.tsx
@@ -39,7 +39,7 @@ export const Calendar = ({ events }: { events: Array<Event> }) => {
     }, [events])
 
     return (
-        <div className="mx-auto max-w-screen-xl">
+        <div className="mx-auto max-w-screen-xl min-w-[100%]">
             <div className="pt-10"></div>
             <div>
                 <h2 className="text-4xl font-bold mb-4">Alle Veranstaltungen</h2>

--- a/src/screens/ContactUs/ContactUs.tsx
+++ b/src/screens/ContactUs/ContactUs.tsx
@@ -4,7 +4,7 @@ import React from "react";
 
 export const ContactUs = () => {
     return (
-        <div className="mx-auto max-w-screen-xl">
+        <div className="mx-auto max-w-screen-xl min-w-[100%]">
             <div className="pt-20"></div>
             <h2 className="text-4xl font-bold mb-4">Kontakt</h2>
 


### PR DESCRIPTION
- Fixed styling using `grid min-h-screen grid-rows-[auto,1fr,auto]`
- Added powershell script for Windows (backend)
- Explicitly set the width to `100%` of _"Contact Us"_ and _"Dienste"_ pages

![Capture](https://github.com/bishoyroufael/stgeorge-kirche-webapp/assets/36182888/16153120-0a2a-40bc-9efa-0adef6e400f5)
